### PR TITLE
build: update the GitHub Pages actions

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -47,12 +47,12 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
         with:
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
@@ -64,7 +64,7 @@ jobs:
       - name: Build with docusaurus
         run: ${{ steps.detect-package-manager.outputs.runner }} build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
 
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -35,7 +35,7 @@ jobs:
             exit 1
           fi
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "16"
           cache: ${{ steps.detect-package-manager.outputs.manager }}


### PR DESCRIPTION
The Pages deploy failed with:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

Neither workflow names that action directly — `actions/upload-pages-artifact@v1` and `actions/deploy-pages@v1` build on it internally, so the versions here are what has to move.

- `upload-pages-artifact` v1 → v3 (the first version on `upload-artifact@v4`)
- `deploy-pages` v1 → v4
- `configure-pages` v3 → v5
- `checkout` and `setup-node` v3 → v4, in `buildAndTest.yml` as well — same class of decay, and `checkout@v3` is heading the same way

Node stays on 16, which is what this site declares (`engines: >=16.14`, Docusaurus 2). Bumping it is a separate question and would want a build to confirm.

Since the deploy triggers on push to `release`, this has to land there before the next attempt succeeds.
