### PR TITLE
doc: add a feature support page for V4 and V2

### DIFF
--- a/docs/odata/feature-support.md
+++ b/docs/odata/feature-support.md
@@ -105,7 +105,7 @@ on a **collection** query, not on a single entity, and `$search` and `groupBy` a
 
 | Feature                          | V4  | V2  | Notes                                                                |
 | -------------------------------- | :-: | :-: | -------------------------------------------------------------------- |
-| Primitive types                  | ✅  | ✅  | See [OData Data Types](./types)                                      |
+| Primitive types                  | ✅  | ✅  | See [OData Data Types](./odata-types)                                      |
 | Converters                       | ✅  | ✅  | See [Converters](../generator/converters/)                           |
 | Enum types                       | ✅  | ➖  | V2 knows no enums; as string enum, numeric enum or string union      |
 | Complex types                    | ✅  | ✅  |                                                                      |

--- a/docs/odata/feature-support.md
+++ b/docs/odata/feature-support.md
@@ -42,7 +42,7 @@ inventoried in the [OData V4 feature matrix][spec-v4] and its [V1–V3 counterpa
 | `$compute`                    | ❌  | ➖  |                                                                           |
 | `$skiptoken`                  | 🔶  | 🔶  | Never built by the client, which is correct; the next link is exposed and followed manually |
 | `$format`                     | ➖  | ➖  | JSON-only client — negotiated through the `Accept` header                 |
-| Custom query options          | 🔶  | 🔶  | Not part of the query builder; possible through the HTTP client's request configuration |
+| Custom query options          | ✅  | ✅  | Not through the query builder but through the HTTP client's request configuration      |
 
 The builder only offers what the resource admits: `$filter`, `$orderby`, `$top`, `$skip` and `$count` exist
 on a **collection** query, not on a single entity, and `$search` and `groupBy` are V4 collections only.
@@ -110,11 +110,12 @@ on a **collection** query, not on a single entity, and `$search` and `groupBy` a
 | Enum types                       | ✅  | ➖  | V2 knows no enums; as string enum, numeric enum or string union      |
 | Complex types                    | ✅  | ✅  |                                                                      |
 | Inheritance and type casts       | ✅  | 🔶  | V4 addresses derived types by cast segment; V2 renders the hierarchy but cannot serialise it |
-| Open types                       | 🔶  | ➖  | Declared properties are typed; dynamic ones are not                  |
+| Open types                       | ✅  | ➖  | The declared properties are typed; the dynamic ones cannot be, since nothing announces them |
 | `IEEE754Compatible`              | ✅  | ➖  | [`v4BigNumberAsString`](../generator/configuration#v4-big-number-handling) |
 | 4.01 short-form control info     | ✅  | ➖  | [`odataVersionV4`](../generator/configuration#odata-401) selects one spelling, requests and responses alike |
 | `metadata=full` / `none`         | 🔶  | ➖  | Through a manual `Accept` header; the extra control information stays untyped |
 | Instance annotations             | 🔶  | 🔶  | Passed through untyped                                               |
+| Vocabulary annotations           | ❌  | ❌  | Not evaluated at all — neither `Core.*` nor `Capabilities.*` nor any other term; the same effects have to be configured by hand |
 | `results` wrapping               | ➖  | ✅  | See [extra results wrapper](../generator/configuration#v2-extra-results-wrapper) |
 
 ## Deliberately Out of Scope
@@ -125,8 +126,6 @@ Not gaps but decisions:
   is nothing to fetch and interpret at runtime — no `$metadata` or service document handling.
 - **Atom / XML payloads.** JSON only.
 - **`$format`.** Format negotiation belongs in the `Accept` header.
-- **Vocabulary evaluation.** Annotations such as `Core.Computed` or `Capabilities.*` are not read; the same
-  effects are reached through explicit configuration.
 
 [spec-v4]: https://github.com/odata2ts/test-reference-model/blob/main/feature-matrix/odata-v4.md
 [spec-v2]: https://github.com/odata2ts/test-reference-model/blob/main/feature-matrix/odata-v1-v3.md

--- a/docs/odata/feature-support.md
+++ b/docs/odata/feature-support.md
@@ -1,0 +1,132 @@
+---
+id: feature-support
+title: Feature Support
+sidebar_position: 2
+---
+
+# Feature Support
+
+What `odata2ts` supports of the OData protocol, for **V4** (4.0 / 4.01) and **V2**.
+
+| Symbol | Meaning                                                             |
+| :----: | ------------------------------------------------------------------- |
+|   ✅   | Supported as a typed, first-class feature                           |
+|   🔶   | Partially supported, or reachable through an escape hatch           |
+|   ❌   | Not supported                                                       |
+|   ➖   | Not applicable — the protocol version has no such thing             |
+
+The tables describe the **client's** perspective: what you can send and what you get back. Server-side
+concerns are out of scope, as is the Atom/XML format — `odata2ts` speaks JSON only.
+
+:::note
+
+This page states what `odata2ts` does. What the **protocol** offers, independent of any implementation, is
+inventoried in the [OData V4 feature matrix][spec-v4] and its [V1–V3 counterpart][spec-v2] in the
+`test-reference-model` repository.
+
+:::
+
+## System Query Options
+
+| Option                        | V4  | V2  | Notes                                                                     |
+| ----------------------------- | :-: | :-: | ------------------------------------------------------------------------- |
+| `$select`                     | ✅  | ✅  | Top-level properties; `select("*")` produces the wildcard                 |
+| `$expand`                     | ✅  | ✅  | [`expand()`](../query-builder/querying#expand) for plain expansion        |
+| `$expand` with nested options | ✅  | ➖  | [`expanding()`](../query-builder/querying#complex-expanding); V2's syntax cannot carry nested options at all |
+| `$filter`                     | ✅  | ✅  | See [Filtering](#filtering)                                               |
+| `$orderby`                    | ✅  | ✅  | Property paths with `asc()` / `desc()`, multiple criteria                 |
+| `$top` / `$skip`              | ✅  | ✅  |                                                                           |
+| `$count`                      | ✅  | ✅  | V4: `@odata.count` on the response model; V2: `__count`                   |
+| `$search`                     | ✅  | ➖  | Terms and phrases are distinguished automatically                         |
+| `$apply` (aggregation)        | 🔶  | ➖  | `groupBy()` only — no `aggregate`, `topcount`, `compute`                  |
+| `$compute`                    | ❌  | ➖  |                                                                           |
+| `$skiptoken`                  | 🔶  | 🔶  | Never built by the client, which is correct; the next link is exposed and followed manually |
+| `$format`                     | ➖  | ➖  | JSON-only client — negotiated through the `Accept` header                 |
+| Custom query options          | 🔶  | 🔶  | Not part of the query builder; possible through the HTTP client's request configuration |
+
+The builder only offers what the resource admits: `$filter`, `$orderby`, `$top`, `$skip` and `$count` exist
+on a **collection** query, not on a single entity, and `$search` and `groupBy` are V4 collections only.
+
+## Filtering
+
+| Group                | V4  | V2  | Notes                                                                              |
+| -------------------- | :-: | :-: | ---------------------------------------------------------------------------------- |
+| Comparison operators | ✅  | ✅  | `eq`, `ne`, `lt`, `le`, `gt`, `ge`, plus `isNull` / `isNotNull`                    |
+| Logical operators    | ✅  | ✅  | `and`, `or`, `not`                                                                 |
+| `in`                 | ✅  | ✅  | Emulated as `or`-chained equals by default; V4 can render it natively with [`enableNativeInOperator`](../generator/configuration#the-in-operator) |
+| String functions     | 🔶  | 🔶  | `contains`, `startsWith`, `endsWith`, `indexOf`, `length`, `concat`, `toLower`, `toUpper`, `trim`, `matchesPattern`; `substring` and `has` are missing |
+| Arithmetic           | ✅  | ✅  | `add`, `sub`, `mul`, `div`, `mod`                                                  |
+| Number functions     | ✅  | ✅  | `round`, `floor`, `ceiling`                                                        |
+| Date & time functions| 🔶  | 🔶  | The component functions (`year`, `month`, `day`, `hour`, …); `now`, `totalseconds` and date arithmetic are missing |
+| Lambda operators     | ✅  | ➖  | `any()` / `all()` over collections                                                 |
+| `cast` / `isof`      | ❌  | ➖  |                                                                                    |
+| Geo functions        | ❌  | ➖  | Geo types are typed as `string`                                                    |
+| Custom expressions   | ✅  | ✅  | An escape hatch for anything the builder does not model                            |
+
+## Reading and Writing
+
+| Feature                          | V4  | V2  | Notes                                                                       |
+| -------------------------------- | :-: | :-: | --------------------------------------------------------------------------- |
+| Read entity / collection         | ✅  | ✅  | Typed response models per version                                           |
+| Create, update, patch, delete    | ✅  | ✅  | V2 sends `MERGE` where the protocol demands it                              |
+| `$select` / `$expand` on a write | ✅  | ✅  | The same builder as on a read                                               |
+| Editable models                  | ✅  | ✅  | Managed properties are excluded — see [managed properties](../generator/configuration#managed-properties) |
+| Binding an existing entity       | ✅  | ✅  | By key; rendered as `@odata.bind` (4.0), `{"@id": …}` (4.01) or `__metadata.uri` (V2) |
+| Deep insert / deep update        | ✅  | ✅  | Related entities inside the parent's payload                                |
+| Return representation            | ✅  | ➖  | `patch<true>()` plus `Prefer: return=representation`                        |
+| Individual property access       | ✅  | ✅  | Opt-in via [`enablePrimitivePropertyServices`](../generator/configuration#primitive-property-services) |
+| Optimistic concurrency (ETag)    | ❌  | ❌  | No `If-Match` workflow; possible through manual headers                     |
+| Relationship management via `$ref` | ❌ | ➖  |                                                                             |
+| Batch requests                   | ❌  | ❌  | Out of scope of the HTTP client design                                      |
+| Delta / change tracking          | ❌  | ➖  |                                                                             |
+| Asynchronous requests            | ❌  | ➖  |                                                                             |
+
+## Operations
+
+| Feature                    | V4  | V2  | Notes                                                                    |
+| -------------------------- | :-: | :-: | ------------------------------------------------------------------------ |
+| Unbound functions / actions| ✅  | ✅  | V2 has `FunctionImport` only, distinguished by its HTTP method           |
+| Bound operations           | ✅  | ➖  | Generated onto the service of the bound type                             |
+| Typed parameters           | ✅  | ✅  | One parameter model and one q-function / q-action per operation          |
+| Function overloads         | ✅  | ➖  |                                                                          |
+| Composable functions       | ✅  | ➖  | `compose()` applies query options to a function's result                 |
+| Query options in the body  | ✅  | ➖  | `asPostRequest()` moves the query string into `POST …/$query`, for URLs beyond a server's length limit |
+
+## Binary Content
+
+| Feature                        | V4  | V2  | Notes                                                              |
+| ------------------------------ | :-: | :-: | ------------------------------------------------------------------ |
+| Media entities (`$value`)      | ✅  | ✅  | Own service per media entity                                       |
+| Stream properties (`Edm.Stream`) | ✅ | ➖  | Own service per stream property                                    |
+| Streaming transfer             | ✅  | ✅  | Content can be transferred as a stream rather than buffered        |
+| `Edm.Binary`                   | ✅  | ✅  | base64 in the payload                                              |
+
+## Types and Payload Format
+
+| Feature                          | V4  | V2  | Notes                                                                |
+| -------------------------------- | :-: | :-: | -------------------------------------------------------------------- |
+| Primitive types                  | ✅  | ✅  | See [OData Data Types](./types)                                      |
+| Converters                       | ✅  | ✅  | See [Converters](../generator/converters/)                           |
+| Enum types                       | ✅  | ➖  | V2 knows no enums; as string enum, numeric enum or string union      |
+| Complex types                    | ✅  | ✅  |                                                                      |
+| Inheritance and type casts       | ✅  | 🔶  | V4 addresses derived types by cast segment; V2 renders the hierarchy but cannot serialise it |
+| Open types                       | 🔶  | ➖  | Declared properties are typed; dynamic ones are not                  |
+| `IEEE754Compatible`              | ✅  | ➖  | [`v4BigNumberAsString`](../generator/configuration#v4-big-number-handling) |
+| 4.01 short-form control info     | ✅  | ➖  | [`odataVersionV4`](../generator/configuration#odata-401) selects one spelling, requests and responses alike |
+| `metadata=full` / `none`         | 🔶  | ➖  | Through a manual `Accept` header; the extra control information stays untyped |
+| Instance annotations             | 🔶  | 🔶  | Passed through untyped                                               |
+| `results` wrapping               | ➖  | ✅  | See [extra results wrapper](../generator/configuration#v2-extra-results-wrapper) |
+
+## Deliberately Out of Scope
+
+Not gaps but decisions:
+
+- **Runtime metadata access.** `odata2ts` reads the metadata at build time and generates from it, so there
+  is nothing to fetch and interpret at runtime — no `$metadata` or service document handling.
+- **Atom / XML payloads.** JSON only.
+- **`$format`.** Format negotiation belongs in the `Accept` header.
+- **Vocabulary evaluation.** Annotations such as `Core.Computed` or `Capabilities.*` are not read; the same
+  effects are reached through explicit configuration.
+
+[spec-v4]: https://github.com/odata2ts/test-reference-model/blob/main/feature-matrix/odata-v4.md
+[spec-v2]: https://github.com/odata2ts/test-reference-model/blob/main/feature-matrix/odata-v1-v3.md


### PR DESCRIPTION
What `odata2ts` covers of the OData protocol was answerable only by reading the source. This states it per feature area, with a column for **V4** and one for **V2**, and links to the spec inventories in `test-reference-model` for what the protocol offers independently of any implementation.

**Derived from the public API surface, not from prose** — the query builder's per-version operation sets, the q-object path classes, the `v2/` and `v4/` service classes and the generator options. That mattered, because the areas involved moved a lot recently and the older internal analysis had gone stale on nine of them:

| Was recorded as missing | Actually |
| --- | --- |
| media entities, stream properties, `Edm.Binary` | supported, in both versions |
| deep insert / deep update | supported, on by default |
| binding existing entities | on by default, stated by key |
| `$select` into a complex property | supported via `expanding()` |
| composable functions | supported |
| query options in the request body | supported via `asPostRequest()` |
| `select`/`expand` on write requests | supported |
| native `in` operator | supported (V4) |
| `odataVersionV4` | governs responses too, not only requests |

The gaps are stated as plainly as the support — no batch, no ETag workflow, no `$ref`, no delta, no async, and no evaluation of vocabulary annotations. A closing section names what is *deliberately* out of scope, so those are not read as omissions: runtime metadata access (replaced by code generation), Atom/XML and `$format`.

The per-version columns carry information that was not written down anywhere before: V2 has no `$search`, no aggregation, no lambda operators, no bound operations, no enums, and its `$expand` cannot carry nested options at all — the builder reflects each of those.

All nine outgoing documentation links were checked against the anchors they target.
