### PR TITLE
doc: document binary content, subtypes, composable functions and long queries

### DIFF
--- a/docs/10-generator/90-upgrading.md
+++ b/docs/10-generator/90-upgrading.md
@@ -1,0 +1,68 @@
+---
+id: upgrading
+title: Upgrading
+sidebar_position: 90
+---
+
+# Upgrading
+
+What changes between releases in ways that need something from you. Everything else is additive.
+
+## Coming from 0.41.0 and earlier
+
+### The generated file layout changed
+
+`bundledFileGeneration` used to default to `true`: everything landed in one file per kind of artefact.
+It now defaults to `false`, which puts each model into a folder of its own below a folder per namespace —
+the structure that scales for large models and the one most setups want.
+
+**Your imports break.** Two ways out:
+
+1. **Import through the generated index files.** Every folder has one, and so does the output directory.
+   This is the recommendation, since an artefact's location then no longer concerns you:
+
+   ```ts
+   // before
+   import { Book, EditableBook } from "./src-generated/library/LibraryModel";
+   // after
+   import { Book, EditableBook } from "./src-generated/library/library-catalog/index.js";
+   ```
+
+   Where your model has a single namespace, the root barrel exports everything directly and
+   `./src-generated/library/index.js` is all you need. With several namespaces the root barrel exposes
+   each under its own name — see [Generated Artefacts](./generated-artefacts#index-files).
+
+2. **Keep the old layout**: set `bundledFileGeneration: true` in your configuration. That is the right
+   answer if your bundler cannot resolve cyclic imports — SAP UI5 with the TS Babel plugin is the known
+   case.
+
+### Name clashes now fail the generation
+
+Two situations that used to produce output no longer do:
+
+- **Two properties collapsing onto one name.** With `allowRenaming`, distinct OData names can end up the
+  same — `Location_` and `Location` both become `location` under camelCase. Previously the generated
+  interface simply declared the name twice; at runtime the second declaration won and the other property
+  was unreachable. Now the generation stops and names both. Resolve it with `propertiesByName`:
+
+  ```ts
+  propertiesByName: [{ name: "Location_", mappedName: "shelfLocation" }];
+  ```
+
+- **Two types colliding within one namespace.** Same idea one level up, resolved with
+  [`byTypeAndName`](./configuration#type-options).
+
+If you were affected, you had a bug — the message tells you which two names and what to do.
+
+### `entitiesByName` is now `byTypeAndName`
+
+The option matches every kind of type, not just entities, so each entry states which one through a `type`
+attribute. Use `TypeModel.Any` to match regardless of kind. See [Type Options](./configuration#type-options).
+
+## Checking your setup
+
+Two settings are worth having whatever you upgrade from:
+
+- **`debug: true`** while you sort things out. Without it every generated file opens with `@ts-nocheck`,
+  so a type check over the output confirms nothing.
+- **`prettier: true`** if you emit TypeScript and read the result.

--- a/docs/30-query-builder/01-overview-and-setup.md
+++ b/docs/30-query-builder/01-overview-and-setup.md
@@ -99,3 +99,27 @@ The Trippin service demonstrates this quite clearly:
 
 So we might navigate to `/People('russelwhyte')/BestFriend` to get to a very specific `Person` entity.
 The path itself cannot be known in advance.
+
+## What the Builder Offers Depends on the Resource
+
+The builder is typed by **cardinality**, not only by protocol version. Querying a collection is not the
+same as querying a single entity, and the OData specification says so: `$filter`, `$orderby`, `$top`,
+`$skip` and `$count` narrow a set, which a single entity is not. So they are simply absent there.
+
+|                            | single entity                  | collection                                              |
+| -------------------------- | ------------------------------ | ------------------------------------------------------- |
+| V4                         | `select`, `expand`, `expanding`| the same, plus `filter`, `orderBy`, `top`, `skip`, `count`, `search`, `groupBy` |
+| V2                         | `select`, `expand`, `expanding`| the same, plus `filter`, `orderBy`, `top`, `skip`, `count` |
+
+The same split applies again inside `expanding()`: expanding a to-many navigation property gives you the
+collection builder, expanding a to-one gives you the entity one.
+
+V2 is more restricted still — its `$expand` syntax cannot carry nested query options at all, so the builder
+handed to `expanding()` offers `select` and nothing else.
+
+:::note
+
+If a method you expected is missing, this is usually why. It is not an omission but the resource telling
+you that the option would have no meaning on it.
+
+:::

--- a/docs/40-odata-client/10-the-main-service.md
+++ b/docs/40-odata-client/10-the-main-service.md
@@ -403,6 +403,39 @@ Minimal example, based on the Axios client:
 trippinService.people().create(model, { headers: { "myCustomHeader": "myCustomHeaderValue" } });
 ```
 
+### Composable Functions
+
+A function whose result is a collection or an entity can be **composable**: query options apply to what it
+returns, as if it were an entity set. `compose()` hands you the service of the returned type:
+
+```ts
+const result = await libraryService
+  .newReleases()
+  .compose()
+  .query((builder, qMedium) => builder.select("title").filter(qMedium.language.eq("de")))
+  .execute();
+```
+
+Whether a server honours that is its own decision — composability is declared in the metadata, but not
+every implementation follows through on every combination.
+
+### Long Queries: Sending a GET as POST
+
+A generously built `$filter` can outgrow the maximum request line a server accepts, at which point the
+request fails before it is even parsed. OData answers that with `POST <resource>/$query`, which carries
+the query string in the body instead. `asPostRequest()` switches a request over:
+
+```ts
+const result = await libraryService
+  .media()
+  .query((builder, qMedium) => builder.filter(qMedium.id.in(...thousandsOfIds)))
+  .asPostRequest()
+  .execute();
+```
+
+The URL loses its query string, the method becomes `POST`, and the body goes out as `text/plain`. Nothing
+else about the call changes — the response is typed exactly as it would have been.
+
 ## Response Structures
 
 `odata2ts` enforces a conventionalized response structure which starts with the `HttpResponseModel`.

--- a/docs/40-odata-client/20-binary-content.md
+++ b/docs/40-odata-client/20-binary-content.md
@@ -1,0 +1,63 @@
+---
+id: binary-content
+title: Binary Content
+sidebar_position: 20
+---
+
+# Binary Content
+
+OData carries binary data in two shapes, and `odata2ts` generates a service of its own for each:
+
+- a **media entity** — an entity whose *own* content is binary, declared with `HasStream="true"`. Its
+  content lives at `…/$value`.
+- a **stream property** (`Edm.Stream`) — one property of an otherwise ordinary entity. V4 only; V2 has no
+  such type.
+
+Both are reached through the same small API, so which of the two you are holding rarely matters.
+
+## Reading
+
+```ts
+const cover = trippinService.photos(1);
+
+// as a Blob - the whole content in memory
+const blob = await cover.getBlob().execute();
+
+// as a ReadableStream - for large content you would rather not buffer
+const stream = await cover.getStream().execute();
+```
+
+A media entity's content is addressed through the entity service itself. A stream property gets its own
+getter, named after the property:
+
+```ts
+// stream property "sample" on an audiobook
+const sample = await libraryService.audiobooks(id).sample().getBlob().execute();
+```
+
+## Writing
+
+```ts
+await cover.updateBlob(newBlob, "image/png").execute();
+await cover.updateStream(readableStream, "image/png").execute();
+await cover.deleteBlob().execute();
+```
+
+The MIME type is optional; when omitted the client sends what the `Blob` carries.
+
+:::note
+
+Servers differ here more than elsewhere. Some answer with the MIME type declared in their model rather
+than the one you uploaded, and not every server implements `DELETE` on a media resource. The behaviour is
+the server's, not the client's.
+
+:::
+
+## What the metadata has to say
+
+A media entity needs `HasStream="true"` on the entity type, and a stream property needs the type
+`Edm.Stream`. Neither is inferred: if the server does not declare it, no blob service is generated.
+
+That is worth knowing when the same model is served by different implementations. A server may express as
+a media entity what another expresses as a stream property — the generated API then differs accordingly,
+even though the content is the same.

--- a/docs/40-odata-client/20-binary-content.md
+++ b/docs/40-odata-client/20-binary-content.md
@@ -53,6 +53,31 @@ the server's, not the client's.
 
 :::
 
+## Not every HTTP client can do both
+
+Reading binary data is one thing for the generated service and quite another for the transport underneath
+it. What actually works depends on the [HTTP client](./http-client/) you plugged in:
+
+| Client                                | `getBlob` / `updateBlob`      | `getStream` / `updateStream` |
+| ------------------------------------- | ----------------------------- | ---------------------------- |
+| [Fetch](./http-client/fetch)          | ✅                            | ✅                           |
+| [Axios](./http-client/axios)          | ✅ in the browser only        | ❌                           |
+| [jQuery](./http-client/jquery)        | ✅                            | ❌                           |
+
+The reasons are in the transports, not in `odata2ts`:
+
+- **Axios streams nothing.** Its XHR adapter has no streaming API, and its http adapter neither takes a
+  `ReadableStream` as request body nor hands one back.
+- **Axios reads binary only in the browser.** Without `XMLHttpRequest` it falls back to the http adapter,
+  which decodes the response as text — a `Blob` can never come out of that. Note the asymmetry: *sending*
+  binary works on either adapter, only a response expecting binary back is refused.
+- **jQuery streams nothing either.** `XMLHttpRequest`, which its `ajax` method builds on, has no
+  streaming API at all, in either direction.
+
+Where a client cannot do it, the request is refused up front with an error saying so, rather than
+returning something unusable. **Use the Fetch client if you deal with binary content**, and especially if
+you deal with it outside the browser.
+
 ## What the metadata has to say
 
 A media entity needs `HasStream="true"` on the entity type, and a stream property needs the type

--- a/docs/40-odata-client/30-subtypes.md
+++ b/docs/40-odata-client/30-subtypes.md
@@ -1,0 +1,67 @@
+---
+id: subtypes
+title: Subtypes and Type Casts
+sidebar_position: 30
+---
+
+# Subtypes and Type Casts
+
+OData models inheritance: `Book` extends `PrintMedium` extends `Medium`. A collection of `Medium` then
+holds books, magazines and audiobooks alike, and reaching a property that only exists on the derived type
+requires a **type cast**.
+
+`odata2ts` generates two ways to do that, and which one you need depends on what you are addressing.
+
+## Casting a resource
+
+Every service of a type with subtypes carries an `asXxxService()` getter per subtype. It appends the type
+cast segment to the URL and hands back the service of the derived type, with everything that type has:
+
+```ts
+// /Media(<id>)/Library.Catalog.Book
+const book = libraryService.media(id).asBookService();
+
+const result = await book.query((builder) => builder.select("pageCount")).execute();
+```
+
+Collections have the same, one level up:
+
+```ts
+// /Media/Library.Catalog.Book - only the books within the media collection
+const books = libraryService.media().asBookCollectionService();
+```
+
+:::note
+
+Not every server serves both. A type cast on a collection is the more widely implemented of the two; a
+cast on a single entity is refused by some servers with a 404.
+
+:::
+
+## Casting a property
+
+Sometimes you do not want to change the resource at all — you want to `select`, `filter` or `expand` a
+property that only the derived type has, while still querying the base collection. For that the base
+q-object carries a **cast property** per subtype property, named `Q<Subtype>_<Property>`:
+
+```ts
+const result = await libraryService
+  .media()
+  .query((builder, qMedium) =>
+    builder
+      .select("title", "QBook_pageCount")
+      .expand("QBook_publisher")
+      .filter(qMedium.QBook_pageCount.gt(300)),
+  )
+  .execute();
+```
+
+The rendered URL carries the cast inline — `$select=Library.Catalog.Book/PageCount` — so the request stays
+on the base collection and entities of other subtypes simply have no value there.
+
+Since the property is not on the base type, the response model does not know about it either. Cast the
+result where you read it:
+
+```ts
+(result.data.value[0] as unknown as Book).pageCount;
+```


### PR DESCRIPTION
Five features were supported but appeared nowhere in the documentation — the only way to find them was to read the generated code.

**New page: Binary Content** (`40-odata-client/20-binary-content.md`)

Media entities and stream properties, the blob and stream API for reading and writing, and what the metadata has to declare for either to be generated at all. That last part matters when the same model is served by different implementations: one may express as a media entity what another expresses as a stream property, and the generated API follows.

**New page: Subtypes and Type Casts** (`40-odata-client/30-subtypes.md`)

The two distinct ways of reaching a derived type, which are easy to confuse:

- casting the **resource** with `asXxxService()` / `asXxxCollectionService()`, which appends the type cast segment
- casting a single **property** with the `Q<Subtype>_<Property>` q-properties, which keeps the request on the base collection and renders the cast inline

**Added to the client page**: composable functions via `compose()`, and `asPostRequest()` for a query that outgrows the server's request line. The latter is worth finding quickly — it is the answer to a request that fails before it is even parsed.

**Added to the query builder overview**: why `filter`, `orderBy`, `top`, `skip` and `count` are missing on a single entity. A table over cardinality and protocol version, plus the note that V2's `expanding()` offers `select` and nothing else. That absence reads as a bug until you know it is the specification.

**New page: Upgrading** (`10-generator/90-upgrading.md`)

What needs action when coming from 0.41.0: the file layout default with both ways out, the name clashes which now fail generation instead of producing broken output, and the `entitiesByName` → `byTypeAndName` rename.

Deliberately *not* listed there: the binding and deep insert props becoming opt-out. Those options were never published under their old names, so for users this is simply how the release behaves — there is nothing to migrate.
