### PR TITLE
doc: fix broken samples, logical operators, and document namespaces

### DIFF
--- a/docs/01-getting-started/10-data-models-only.md
+++ b/docs/01-getting-started/10-data-models-only.md
@@ -48,4 +48,12 @@ Run the `gen-odata` script:
 npm run gen-odata
 ```
 
-You can now use the generated models in your code by importing them from the configured build folder.
+You can now use the generated models in your code. Import them through the **index files** the generator
+writes next to the artefacts — one per folder and one for the output directory as a whole:
+
+```ts
+import type { Person, EditablePerson } from "../build/trippin/index.js";
+```
+
+That way the import does not depend on which file a model ended up in; see
+[Generated Artefacts](../generator/generated-artefacts#index-files).

--- a/docs/01-getting-started/20-type-safe-querying.md
+++ b/docs/01-getting-started/20-type-safe-querying.md
@@ -56,8 +56,9 @@ npm run gen-odata
 Create the builder by providing the path to the resource and the generated query object:
 
 ```ts
-import { createUriBuilderV4 } from "@odata2ts/odata-uri-builder";
-import { qPerson } from "../build/QTrippin"
+import { createQueryBuilderV4 } from "@odata2ts/odata-query-builder";
+// through the generated index file, so the import survives a change of the file layout
+import { qPerson } from "../build/trippin/index.js";
 
 createQueryBuilderV4("People", qPerson)
   .select("lastName", "age") // => typesafe: only model attributes are allowed
@@ -72,4 +73,4 @@ createQueryBuilderV4("People", qPerson)
   .build();
 ```
 
-For V2, you use the factory function `createUriBuilderV2`.
+For V2, you use the factory function `createQueryBuilderV2`.

--- a/docs/01-getting-started/30-full-fledged-service.md
+++ b/docs/01-getting-started/30-full-fledged-service.md
@@ -66,8 +66,8 @@ npm run gen-odata
 Initialize the main OData service:
 
 ```ts
-// the generate main service
-import { TrippinService } from "../build/trippin/TrippinService";
+// the generated main service, imported through the index file of the output directory
+import { TrippinService } from "../build/trippin/index.js";
 import { FetchClient } from "@odata2ts/http-client-fetch";
 
 const baseUrl = "https://services.odata.org/TripPinRESTierService"

--- a/docs/30-query-builder/01-overview-and-setup.md
+++ b/docs/30-query-builder/01-overview-and-setup.md
@@ -60,7 +60,7 @@ You need to provide two arguments:
 
 ```ts
 import { createQueryBuilderV4  } from "@odata2ts/odata-query-builder";
-import { QPerson } from "../generated/trippin/QTrippin"
+import { QPerson } from "../generated/trippin/index.js";
 
 const builder = createQueryBuilderV4("people", new QPerson());
 ```

--- a/docs/30-query-builder/10-querying.md
+++ b/docs/30-query-builder/10-querying.md
@@ -44,10 +44,10 @@ path and the appropriate query object. At the end you will have to call `build()
 URI string, which will be properly encoded.
 
 ```ts
-import { createUriBuilderV2, createUriBuilderV4 } from "@odata2ts/odata-query-builder";
+import { createQueryBuilderV2, createQueryBuilderV4 } from "@odata2ts/odata-query-builder";
 
 // create the builder
-const builder = createUriBuilderV4("People", qPerson);
+const builder = createQueryBuilderV4("People", qPerson);
 // ...
 const result = builder.build();
 ```

--- a/docs/30-query-builder/20-filtering.md
+++ b/docs/30-query-builder/20-filtering.md
@@ -18,7 +18,7 @@ entities and complex types.
 Each property of such a `Query Object` provides all the filter methods available for its data type.
 
 ```ts
-import { QPerson } from "../generated/trippin/QTrippin";
+import { QPerson } from "../generated/trippin/index.js";
 
 const qPerson = new QPerson();
 builder

--- a/docs/40-odata-client/10-the-main-service.md
+++ b/docs/40-odata-client/10-the-main-service.md
@@ -471,7 +471,8 @@ Let's work with generics here, so whatever the type in question, we call it `T`:
 
 | Return Type           | OData Version | Response Structure                               |
 | --------------------- | ------------- | ------------------------------------------------ |
-| Collection            | V4            | `{ "@odata.count"?: number; value: Array<T> }`   |
+| Collection            | V4 (4.0)      | `{ "@odata.count"?: number; value: Array<T> }`   |
+| Collection            | V4 (4.01)     | `{ "@count"?: number; value: Array<T> }`         |
 | Entity / Complex Type | V4            | `T`                                              |
 | Value Type            | V4            | `{ value: T }`                                   |
 | Collection            | V2            | `{ d: { __count?: string; results: Array<T> } }` |
@@ -480,6 +481,11 @@ Let's work with generics here, so whatever the type in question, we call it `T`:
 
 As you can see, V4 is pretty straightforward: The `data` property will be filled with the entity or
 complex type model, or we get an additional object containing the `value` property.
+
+The two V4 rows differ only in how the **control information** is spelled: 4.01 drops the `odata.` prefix.
+Which one you get follows the [`odataVersionV4`](../generator/configuration#odata-401) option — the
+generated response models are typed for the version you configured, and the client declares that version
+on every request so the service answers in the matching form.
 
 In V2 things are more complicated: Each kind of request wraps the response in an extra object with the
 property `d`. Collections are wrapped again, like in V4, but with the property `results` (this is not


### PR DESCRIPTION
Three commits, and it grew along the way — the first one started as "mention the index files in Getting Started" and turned up samples that do not run.

## Code samples that do not run

- **A package that is not the package.** `20-type-safe-querying.md` imported `createUriBuilderV4` from `@odata2ts/odata-uri-builder`, then called `createQueryBuilderV4` — wrong package, wrong function, inconsistent within one snippet. `10-querying.md` had the same wrong factory names. Verified against the package's `index.ts`: it is `@odata2ts/odata-query-builder` with `createQueryBuilderV2` / `createQueryBuilderV4`
- **Q-objects imported from a file that no longer holds them.** Four samples imported `QPerson` / `qPerson` from `../build/QTrippin`. Since the file layout default changed, that file holds only the q-objects of *unbound operations*. All samples now go through the generated index files, which is the recommended route anyway
- **"Import them from the configured build folder"** without saying how; now shows the import

Plus the 4.01 row in the response structures table.

## Reported issues

**odata2ts.github.io#32 and #34** turned out to be more than "check": the example promised `not(LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen')` as the result of `A.or(B).not()`. Neither operator adds parentheses, so what comes out is `not LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen'` — and since OData binds `not` more tightly than `or`, that is a **different question**, not different formatting. Corrected, with `group()` documented as the way to put the parentheses where they belong.

**#28** — `any()` and `all()` take the lambda variable name as a second argument, shown with a nested example, which is where the default `a` would otherwise shadow.

**#33** — `QSelectExpression` for referencing something the generated type has no name for, with the trade stated plainly: the string goes through unchecked.

**#27** — the two remaining points of the checklist. What a namespace is and why it matters was assumed knowledge everywhere it came up, and aliases had no mention at all although odata2ts resolves them and accepts them in `byTypeAndName`. The other three points of that issue are already covered by earlier PRs.

**#31** needs no change here: `enumType` is documented in the configuration reference already.
