### PR TITLE
doc: document query builder grouping, lambda prefixes, QSelectExpression and namespace support

### DIFF
--- a/docs/10-generator/10-generated-artefacts.md
+++ b/docs/10-generator/10-generated-artefacts.md
@@ -5,6 +5,34 @@ sidebar_position: 10
 
 # Generated Artefacts
 
+## Namespaces
+
+Every OData schema declares a **namespace**, and every type in it is really addressed by its *fully
+qualified* name: `Library.Catalog.Book`, not just `Book`. One service may carry several schemas, and then
+the same simple name can legitimately appear more than once — a `Branch` in `Library.Circulation` and
+another in `PublisherRegistry` are two different types.
+
+`odata2ts` works with the fully qualified name internally but generates from the plain one, because
+`Library.Catalog.Book` is no name for a TypeScript interface. The namespace survives in two places:
+
+- as a **folder** in the generated output, so the two `Branch` types never share a directory
+- in the **index files**, where a root barrel re-exports each namespace under its own name once there is
+  more than one — see [Index Files](#index-files)
+
+Where that is not enough — because the bundled layout puts everything in one file, or because you simply
+want to tell them apart when reading — give one of them a name of its own, see
+[name clashes](./configuration#name-clashes).
+
+### Aliases
+
+A schema may declare an **alias** next to its namespace, a shorthand that references within the metadata
+may use instead of the full one: `Self.Book` rather than `Library.Catalog.Book`.
+
+`odata2ts` reads the alias and resolves references written either way, so an alias in your metadata needs
+no attention. It is also accepted where you address a type yourself: an entry in
+[`byTypeAndName`](./configuration#type-options) may name the type by its simple name, its fully qualified
+name or its aliased one.
+
 ## File Layout
 
 By default the artefacts of one model live together in a **folder of their own**, one level below a folder

--- a/docs/30-query-builder/10-querying.md
+++ b/docs/30-query-builder/10-querying.md
@@ -117,6 +117,20 @@ In V4 you use the `expanding` operation of the query builder and then `select` t
 And it works the same way for V2 when using `odata2ts`: Behind the scenes the V4 syntax is translated
 to a deep select including the necessary expand. See [complex expanding in V2](#complex-expanding-in-v2).
 
+### Selecting Something the Type Does Not Know
+
+`select()` and `expand()` accept only the properties of the query object, which is the point of them. Where
+you need something the generated type has no name for — a property an open type carries at runtime, or one
+the metadata does not declare — wrap it in a `QSelectExpression`:
+
+```ts
+import { QSelectExpression } from "@odata2ts/odata-query-objects";
+
+builder.select("lastName", new QSelectExpression("SomeDynamicProperty"));
+```
+
+The string goes into the query as it is, so nothing checks it — that is the trade you are making.
+
 ## Expand
 
 By default, associated entities are not included in response structures (in contrast to ComplexTypes).

--- a/docs/30-query-builder/20-filtering.md
+++ b/docs/30-query-builder/20-filtering.md
@@ -117,14 +117,25 @@ You control this aspect via the filter expression itself, since any `QFilterExpr
 the logical operators:
 
 ```ts
-builder.filter(
-  qPerson.lastName.eq("Smith")
-    .or(qPerson.firstName.eq("Rumpelstilzchen"))
-    .not()
-)
+builder.filter(qPerson.lastName.eq("Smith").or(qPerson.firstName.eq("Rumpelstilzchen")));
 ```
 
-Result: `$filter=not(LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen')`
+Result: `$filter=LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen'`
+
+### Grouping
+
+Combining expressions adds **no parentheses of its own**, and neither does `not`. Since OData binds `not`
+and `and` more tightly than `or`, that matters as soon as you mix them: put the grouping where you mean it
+with `group()`.
+
+```ts
+builder.filter(qPerson.lastName.eq("Smith").or(qPerson.firstName.eq("Rumpelstilzchen")).group().not());
+```
+
+Result: `$filter=not (LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen')`
+
+Without the `group()` the same chain yields `not LastName eq 'Smith' or FirstName eq 'Rumpelstilzchen'`,
+which asks a different question.
 
 Specification: OData V4 URL Conventions on [Logical Operators](https://docs.oasis-open.org/odata/odata/v4.01/os/part2-url-conventions/odata-v4.01-os-part2-url-conventions.html#sec_LogicalOperators).
 
@@ -242,3 +253,13 @@ Also called "Lambda Functions".
 | -------- | ---------------------------------------------- | ------------------------------ | --------------------------------------------------------------------------- |
 | any      | `q.trips.any((qTrip) => qTrip.price.lt(1000))` | `Trips/any(a:a/Price lt 1000)` | True if any member of the collection attribute matches the filter criteria. |
 | all      | `q.trips.all((qTrip) => qTrip.price.lt(1000))` | `Trips/all(a:a/Price lt 1000)` | True if all members of the collection attribute match the filter criteria.  |
+
+The lambda variable is called `a` by default. Nesting one lambda inside another would then shadow it, so
+both operators take the variable name as a second argument:
+
+```ts
+qPerson.trips.any((qTrip) => qTrip.planItems.any((qItem) => qItem.confirmed.eq(true), "b"), "a");
+```
+
+Result: `Trips/any(a:a/PlanItems/any(b:b/Confirmed eq true))`
+


### PR DESCRIPTION
Recovers two commits that were pushed to `doc/getting-started-and-responses` **after** #41 had already been merged, so they never reached `release`. Same content, rebased onto the merged state — verified identical by `git patch-id` (`d2fee74` → `b34b790`, `169b549` → `232916e`).

- Fix the logical operator example, which showed a combination the builder does not produce that way.
- Document grouping, the lambda prefixes and `QSelectExpression` in the filtering guide.
- Document namespaces and alias support in the generated artefacts guide.