### PR TITLE
fix: let the docs site deploy again

### DIFF
--- a/.github/workflows/buildAndDeploy.yml
+++ b/.github/workflows/buildAndDeploy.yml
@@ -32,10 +32,11 @@ jobs:
         with:
           node-version: 24
           cache: yarn
+      # No static_site_generator here: that input makes the action inject a baseUrl into the
+      # Docusaurus config, which this site does not need - it is served from the root of
+      # odata2ts.github.io and states url and baseUrl itself. Passing it fails the step.
       - name: Setup Pages
         uses: actions/configure-pages@v6
-        with:
-          static_site_generator: docusaurus
       - name: Install dependencies
         run: yarn --immutable
       - name: Build with docusaurus


### PR DESCRIPTION
**The site has not been publishing.** The `Setup Pages` step of the deploy workflow fails, and has been failing since well before the current round of changes — the last six runs on `release` all failed at the same step. In production, `/docs/generator/upgrading` and `/docs/odata/feature-support` both answer 404, so several merged doc PRs never went live.

The cause is the `static_site_generator: docusaurus` input of `actions/configure-pages`, which makes the action rewrite the Docusaurus config to inject a `baseUrl`. It reports the failure as `TypeError: error must be an instance of Error`, which hides whatever went wrong underneath.

This site does not need the injection: it is served from the root of `odata2ts.github.io` and states `url` and `baseUrl` in its own config. Dropping the input leaves the built output exactly as it is.

Pages itself is fine — `build_type` is already `workflow`, so no repository setting needs changing.

Worth watching the deploy run on merge: this is the one step that cannot be verified from a pull request, since the workflow only runs on a push to `release`.