### PR TITLE
chore: align the repo conventions with the sibling repos

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) 2023 odata2ts
+
+All rights reserved.
+
+This documentation website and its content - including all text, images,
+configuration and source code in this repository - are the intellectual property
+of the odata2ts project and are protected by copyright law.
+
+No part of this repository may be reproduced, distributed, translated or used to
+create derivative works, in any form or by any means, without the prior written
+permission of the copyright holder.
+
+Viewing the published website at https://odata2ts.github.io and reading this
+repository is of course permitted, as is quoting short passages with attribution
+under applicable copyright law.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,78 @@
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/odata2ts/odata2ts.github.io/buildAndDeploy.yml?branch=release&style=for-the-badge)](https://github.com/odata2ts/odata2ts.github.io/actions/workflows/buildAndDeploy.yml)
+
 # Documentation Website of odata2ts
 
-This website is built using [Docusaurus 2](https://docusaurus.io/).
+This repository contains the source of the official documentation website of
+[odata2ts](https://github.com/odata2ts/odata2ts), published at
+[https://odata2ts.github.io](https://odata2ts.github.io/).
 
-### Installation
+It is built with [Docusaurus](https://docusaurus.io/) and serves two separate documentation sections:
 
-```
-$ yarn
-```
+- `docs/` - **Documentation**: everything about odata2ts itself, from the generator over the converters
+  to the generated OData client. Navigation: [sidebars.js](./sidebars.js).
+- `odata-concepts/` - **OData Concepts**: everything about the OData protocol itself, independent of
+  odata2ts. Navigation: [sidebarsConcepts.js](./sidebarsConcepts.js).
 
-### Local Development
+Everything else is the site itself: `src/` (React components, pages and styles), `static/` (images and
+other assets) and [docusaurus.config.js](./docusaurus.config.js) (site configuration, navbar, footer and
+the URL redirects that keep former documentation paths alive).
 
-```
-$ yarn start
-```
+## Local Development
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+Prerequisites: Node.js and Yarn.
 
-### Build
-
-```
-$ yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
-
-```
-$ USE_SSH=true yarn deploy
+```shell
+yarn install
+yarn start
 ```
 
-Not using SSH:
+This starts a local development server and opens a browser window; most changes are reflected live.
+Note that the URL redirects configured in `docusaurus.config.js` only take effect in a production build.
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
+Before opening a pull request, run the same checks that CI runs:
+
+```shell
+yarn typecheck
+yarn check-format
+yarn build
 ```
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+`yarn format` applies the formatting. `yarn build` generates the static site into `build/` and is the
+check that matters most: broken links and broken anchors fail the build. `yarn serve` serves that
+build locally, `yarn clear` removes the Docusaurus caches.
+
+## Branches and Deployment
+
+This repository uses two long-lived branches:
+
+- **`main`** collects the work. Every pull request targets `main`, and everything that is finished
+  lands there - including documentation for features that are not released yet.
+- **`release`** is what the live site shows. It is only advanced once the corresponding odata2ts
+  release is out, by merging `main` into it.
+
+That split exists so that documentation can be written ahead of a release without publishing it
+early. `release` is never worked on directly: it only ever receives what has already passed
+through `main`.
+
+The site is deployed to GitHub Pages by the
+[buildAndDeploy](./.github/workflows/buildAndDeploy.yml) workflow, which runs on every push to
+`release` and can also be triggered manually from the Actions tab. There is no manual deployment
+step - in particular, the site is not served from a `gh-pages` branch.
+
+Pull requests are verified by the [buildAndTest](./.github/workflows/buildAndTest.yml) workflow,
+which type-checks, checks the formatting and builds the site.
+
+## Support, Feedback, Contributing
+
+If you have any sorts of questions use [GitHub Discussions](https://github.com/odata2ts/odata2ts/discussions)
+of the main `odata2ts` repository.
+
+This project is open to feature requests, suggestions, bug reports, and the like
+via [GitHub issues](https://github.com/odata2ts/odata2ts/issues) of the main `odata2ts` repository.
+
+Contributions and feedback are encouraged and always welcome. Documentation gaps are bugs: if you did
+not find the answer you needed here, that alone is worth an issue.
+
+## License
+
+Copyright (c) odata2ts, all rights reserved. See [License](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "build": "docusaurus build",
     "check-format": "prettier --check .",
     "clear": "docusaurus clear",
-    "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
     "format": "prettier --write .",
     "serve": "docusaurus serve",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "schedule:weekly"],
+  "dependencyDashboard": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "description": "Docusaurus and its ecosystem packages must move as one - a partial upgrade mixes plugin and core versions and breaks the build. Never automerge: CI can prove that the site still builds, not that it still looks right",
+      "matchPackageNames": ["@docusaurus/**", "@mdx-js/**", "prism-react-renderer"],
+      "groupName": "docusaurus",
+      "automerge": false
+    },
+    {
+      "description": "React and its types belong together, and @types/react additionally sits in 'resolutions' - a lone update there would fight the grouped one",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "groupName": "react"
+    },
+    {
+      "description": "Group all prettier-related packages together",
+      "matchPackageNames": ["prettier", "prettier-plugin-packagejson", "@ianvs/prettier-plugin-sort-imports"],
+      "groupName": "prettier"
+    },
+    {
+      "description": "TypeScript is a manually evaluated upgrade here: @docusaurus/tsconfig still sets the deprecated baseUrl, which TypeScript 7 rejects (see the note in tsconfig.json) - the jump needs a Docusaurus release first",
+      "matchPackageNames": ["typescript"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    },
+    {
+      "description": "Automerge safe devDependency patch/minor updates once CI is green",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "dev dependencies (patch/minor)",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Never automerge major updates - always requires manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
- add `renovate.json` in the shape used by the sibling repos, adapted to this one: `@docusaurus/**` and its ecosystem grouped and never automerged, React grouped with `@types/react` because of the `resolutions` entry, `typescript` behind dependency dashboard approval as long as `@docusaurus/tsconfig` sets the deprecated `baseUrl` that TypeScript 7 rejects
- add an explicit copyright notice - the repo had no `LICENSE` at all so far
- rewrite the README, which was still Docusaurus boilerplate: it spoke of Docusaurus 2 and described a `gh-pages` deployment via `yarn deploy` that does not exist here, the site is deployed by the Pages workflow
- document the two-branch convention in the README: everything lands on `main`, `release` is advanced by merging `main` into it once the corresponding odata2ts release is out
- describe the split between the `docs/` and `odata-concepts/` sections and the checks to run before opening a pull request
- drop the dead `deploy` script from `package.json`