### PR TITLE
doc: adapt to the dropped HTTP client generic

### DIFF
--- a/docs/06-odata-client/10-the-main-service.md
+++ b/docs/06-odata-client/10-the-main-service.md
@@ -463,11 +463,10 @@ See [upgrading](../upgrading#a-request-is-now-a-command-you-execute).
 ### Request Configuration
 
 Whatever the request - CRUD or custom - you always have the option to pass a request configuration.
-It goes to `execute()`, which is what performs the request. At the utmost minimum, you should be able to
-set custom headers for the request.
+It goes to `execute()`, which is what performs the request.
 
-However, the type of the request configuration is entirely dependent on the chosen [HTTP client](./http-client/).
-Minimal example, based on the Axios client:
+Two fields are common to every [HTTP client](./http-client/) and therefore need nothing else from you:
+`headers` and `params`.
 
 ```ts
 await trippinService
@@ -476,8 +475,20 @@ await trippinService
   .execute({ headers: { myCustomHeader: "myCustomHeaderValue" } });
 ```
 
-It applies to that one request only. For headers that should go out with every request, configure the
-[HTTP client](./http-client/) instead.
+Beyond those two, the configuration is whatever the chosen HTTP client accepts, and the generated service
+has no way of knowing which client it was handed. So name the client's config type on the call:
+
+```ts
+import { FetchRequestConfig } from "@odata2ts/http-client-fetch";
+
+await trippinService.people().query().execute<FetchRequestConfig>({ credentials: "include", cache: "no-store" });
+```
+
+Each HTTP client documents its own config type: `FetchRequestConfig`, `AxiosRequestConfig` and
+`JQueryRequestConfig` respectively - all of them extending the common `ODataRequestConfig`.
+
+A configuration applies to that one request only. For headers that should go out with every request,
+configure the [HTTP client](./http-client/) instead.
 
 ### Composable Functions
 

--- a/docs/09-upgrading.md
+++ b/docs/09-upgrading.md
@@ -8,6 +8,41 @@ sidebar_position: 9
 
 What changes between releases in ways that need something from you. Everything else is additive.
 
+## Coming from 0.42.0
+
+### Services are no longer generic over the HTTP client
+
+Every generated service used to carry the HTTP client as a type parameter, for one reason only: so that
+`execute()` could type the request configuration as whatever the chosen client accepts. That type
+parameter is gone.
+
+Wherever it was inferred — which is every `new TrippinService(httpClient, baseUrl)` — nothing changes.
+It only shows where you wrote a service type out, for instance to hold one in a field or hand it to a
+function:
+
+```ts
+// before
+let service: TrippinService<FetchClient>;
+// after
+let service: TrippinService;
+```
+
+The service is now assignable regardless of the client, so this also stops the type parameter from
+spreading through your own signatures.
+
+For `execute()` the common fields `headers` and `params` remain available without any type argument.
+A field belonging to a specific client now needs that client's config type on the call — imported from
+the client's own package, here `FetchRequestConfig` from `@odata2ts/http-client-fetch`:
+
+```ts
+// before
+await cmd.execute({ credentials: "include" });
+// after
+await cmd.execute<FetchRequestConfig>({ credentials: "include" });
+```
+
+See [Request Configuration](./odata-client/the-main-service#request-configuration).
+
 ## Coming from 0.41.0 and earlier
 
 ### The generated file layout changed


### PR DESCRIPTION
- describe request configuration without the service's HTTP client generic: `headers` and `params` are common to every client and need no type argument, anything beyond those takes the client's own config type on the `execute()` call
- name the config types of the three HTTP clients (`FetchRequestConfig`, `AxiosRequestConfig`, `JQueryRequestConfig`) and their common `ODataRequestConfig` base
- add the 0.42.0 upgrade notes: a written-out service type loses its type argument, an inferred one is unaffected