### PR TITLE
feat(configuration): document deepInsertProps and what changed since 0.43.0

### DIFF
--- a/docs/04-generator/02-configuration.md
+++ b/docs/04-generator/02-configuration.md
@@ -18,6 +18,7 @@ so that you only need to provide those settings which diverge from that.
 ```ts
 import {
   ConfigFileOptions,
+  DeepInsertProps,
   EmitModes,
   KeyProperties,
   ManagedPropertyMode,
@@ -58,7 +59,7 @@ const defaultConfig = {
   unflattenComplexTypes: false,
   enumType: "string",
   disableBindingProps: false,
-  disableDeepInsertProps: false,
+  deepInsertProps: DeepInsertProps.all,
   naming: {
     models: {
       namingStrategy: NamingStrategies.PASCAL_CASE,
@@ -206,7 +207,7 @@ Here is the list of all **base settings** of the config file. By and large this 
 | enumSynthesized                     | `EnumSynthesis`                           | –                 | Synthesize an enum from annotation data (for CAP mainly). See [Synthesized Enums (for CAP)](#synthesized-enums-for-cap)                                                                          |
 | unflattenComplexTypes               | `boolean`                                 | `false`           | Group properties which the service states flat (`Address_City`) back into one complex property. See [flattened complex types](#flattened-complex-types)                                          |
 | disableBindingProps                 | `boolean`                                 | `false`           | Don't allow to bind an existing entity to a navigation property by its key. See [binding and deep insert](#binding-and-deep-insert)                                                              |
-| disableDeepInsertProps              | `boolean`                                 | `false`           | Don't allow to create or update related entities within the payload of their parent. See [binding and deep insert](#binding-and-deep-insert)                                                     |
+| deepInsertProps                     | `DeepInsertProps`                         | `"all"`           | Which navigation properties may carry a related entity within the payload of their parent. Allowed are: all, composition-only, none. See [deepInsertProps](#deepinsertprops)                     |
 | disableAutomaticNameClashResolution | `boolean`                                 | `false`           | Turn off the counter odata2ts appends when one name results from several types; only relevant with `bundledFileGeneration`. See [name clashes](#name-clashes)                                    |
 | enablePrimitivePropertyServices     | `boolean`                                 | `false`           | Generate services for primitive properties, allowing to read, update and delete a single property (excluding stream properties). See [primitive property services](#primitive-property-services) |
 | v4.bigNumberAsString                | `boolean`                                 | `false`           | Retrieve types of `Edm.Int64` and `Edm.Decimal` as `string` instead of `number`. See [handling big numbers](#big-number-handling)                                                                |
@@ -605,8 +606,54 @@ CAP also supports an alternative as it additionally maps the key of the associat
 as simple property, e.g. if the entity has a navigation property `BestFriend` then you automatically
 get `BestFriend_ID`. Setting a new id on this property is effectively the same as `Binding`.
 
-You can switch off both features individually with `disableBindingProps`
-and `disableDeepInsertProps`.
+You can switch off the binding props with `disableBindingProps`. The deep insert props are steered by
+`deepInsertProps`, which has three settings.
+
+### `deepInsertProps`
+
+| Value              | Effect                                                                             |
+| ------------------ | ---------------------------------------------------------------------------------- |
+| `all`              | The default: every navigation property carries the deep insert shape.              |
+| `composition-only` | Only a navigation property marked `ContainsTarget="true"` carries it. **For CAP.** |
+| `none`             | No navigation property carries it.                                                 |
+
+`all` is what the protocol allows. The specification puts no condition on a deep insert: each nested
+entity is processed "as if it was posted against the original target URL extended with the navigation
+path to this related entity".
+
+#### `composition-only` is for CAP, and narrower than the protocol
+
+It exists because of the CAP limitation described above: deep writes run along compositions only. Sending
+a nested entity for an association gets you a **400** for a to-one and a **silent no-op** for a to-many —
+the payload is accepted, and quietly dropped. This setting takes those properties out of the editable
+models, leaving the binding, which does work.
+
+CAP has to be told to say which relationship is which, because it emits no `ContainsTarget` by default.
+Either switch containment on for every composition:
+
+```json title="package.json"
+{ "cds": { "odata": { "containment": true } } }
+```
+
+or annotate a single one, which works without the global flag:
+
+```cds
+annotate Library.Service.Audiobooks with { Chapters @odata.contained };
+```
+
+Under the global flag, `@odata.contained: false` opts an individual composition back out. Either way the
+contained target **loses its own entity set** and becomes reachable only through its container. capire
+describes containment as opt-in today and as the default of the next major release.
+
+:::warning On other servers this takes away more than it should
+Containment is a statement about _addressing_, not about write permission: it says the target is reached
+through its container, and nothing about what may be written. A server such as ASP.NET Core OData marks
+containment faithfully **and** accepts a deep insert on plain associations, so `composition-only` removes
+properties there for writes that would have succeeded. Use it for CAP, not as a general setting.
+:::
+
+OData V2 knows no containment at all, so a V2 service is exempt from the setting rather than emptied by
+it: every navigation property keeps the deep insert shape.
 
 ## Flattened Complex Types
 

--- a/docs/06-odata-client/10-the-main-service.md
+++ b/docs/06-odata-client/10-the-main-service.md
@@ -274,9 +274,10 @@ await trippinService
   .execute();
 ```
 
-Both are on by default. Switch them off individually with
-[`disableBindingProps`](../generator/configuration#binding-and-deep-insert) and `disableDeepInsertProps`
-if you would rather not have the navigation properties on the editable models at all.
+Both are on by default. Switch the binding off with
+[`disableBindingProps`](../generator/configuration#binding-and-deep-insert); the deep insert props are
+steered by [`deepInsertProps`](../generator/configuration#deepinsertprops), which also has a setting for
+CAP, where deep writes run along compositions only.
 
 To **clear** an existing (optional) association, set the field to `null` in a `patch()` (or `update()`):
 

--- a/docs/09-upgrading.md
+++ b/docs/09-upgrading.md
@@ -8,6 +8,92 @@ sidebar_position: 9
 
 What changes between releases in ways that need something from you. Everything else is additive.
 
+## Coming from 0.43.0 and earlier
+
+### `disableAutoManagedKey` is now `keyProperties`
+
+A key cannot change once the entity exists — that much odata2ts can tell without being told. What it
+cannot tell is **who supplies the value**, the client on create or the server. The old boolean answered
+that with one heuristic; the new option lets you state it.
+
+| before                        | equivalent now                    |
+| ----------------------------- | --------------------------------- |
+| the default                   | `keyProperties: "singleComputed"` |
+| `disableAutoManagedKey: true` | `keyProperties: "strict"`         |
+
+The default changed as well, to `interoperable`: the key stays immutable, but is **never required on
+create**, whatever `nullable` says. That is deliberately not what the specification asks for — it is what
+works against the services people really have, since a server generating keys without annotating them is
+the common case. `strict` is the spec-conformant reading.
+
+The practical difference from the old default: a single key property used to be **absent** from the
+editable models, and is now **present and optional**. Set `keyProperties: "singleComputed"` to keep the
+old shape.
+
+See [Keys & Managed Properties](./generator/configuration#keys--managed-properties).
+
+### Managed properties are read from the service's annotations
+
+`Core.Computed`, `Core.Immutable`, `Core.ComputedDefaultValue` and `Core.Permissions` are now evaluated,
+where previously nothing but the key heuristic and your own per-property configuration had any say. A
+service that states these terms properly needs no configuration at all.
+
+**Your write models may therefore change shape** — a computed property is no longer demanded on create, an
+immutable one no longer offered on update. Nothing is required that was not required before, so this
+relaxes rather than tightens. Switch it off with `annotations: { disableManagedProperties: true }`.
+
+The new `managedPropertyMode` decides how such a property appears: `lenient` (the default) keeps it in
+the write model but never requires it, `strictOmit` takes it out. The per-property `managed` option still
+accepts a boolean, so existing configurations keep working.
+
+### `update()` and `patch()` may take an Updatable model
+
+Where a type has immutable properties of its own, it now gets a second write model beside the editable
+one, and the entity service uses it: `create()` takes `EditableFoo`, `update()` and `patch()` take
+`UpdatableFoo`. Types with nothing immutable about them are unaffected — a second, identical model would
+be noise, so none is generated.
+
+This only concerns you where you wrote such a payload type out by hand; inferred usage is unchanged.
+
+### `has` is offered only for flags enums
+
+`has` used to sit on the shared enum path, so it appeared on **every** enum property, although V4 defines
+it for a flag set alone. Elsewhere it was not refused but silently useless: the server evaluates it
+bitwise over the underlying values, and for a member of `0` every row matches.
+
+It now lives on `QFlagsEnumPath` and `QNumericFlagsEnumPath`, which the generator picks exactly where the
+metadata declares `IsFlags="true"`. **Calling `has` on an enum without that declaration no longer
+compiles.** Regenerate; properties whose enum does carry the flag keep the operator. A collection keeps
+the plain path, since `has` applies to the property rather than to its items.
+
+If the compiler now rejects a `has` you were relying on, that call was never doing what it looked like.
+
+### Enums can be synthesized from `Validation.AllowedValues`
+
+New and opt-in, so it asks nothing of you — listed here only so you know it arrived. Some services declare
+no `<EnumType>` and annotate a plain property with the values it accepts instead, which is CAP's habit;
+`enumSynthesized` turns such an annotation into a real enum. See
+[Synthesized Enums](./generator/configuration#synthesized-enums-for-cap).
+
+`enumType` is unchanged and still decides how enums are rendered.
+
+### `disableDeepInsertProps` is now `deepInsertProps`
+
+The option names what it selects instead of switching a feature off, which leaves room for the third
+setting that came with it:
+
+| before                          | now                       |
+| ------------------------------- | ------------------------- |
+| `disableDeepInsertProps: false` | `deepInsertProps: "all"`  |
+| `disableDeepInsertProps: true`  | `deepInsertProps: "none"` |
+
+The default is unchanged. The new value is `composition-only`, which offers the deep insert shape only
+for navigation properties marked `ContainsTarget="true"` — meant for CAP, where deep writes run along
+compositions and not along associations. See
+[`deepInsertProps`](./generator/configuration#deepinsertprops).
+
+`disableBindingProps` is untouched.
+
 ## Coming from 0.42.0 and earlier
 
 ### Services are no longer generic over the HTTP client


### PR DESCRIPTION
**`deepInsertProps`** replaces `disableDeepInsertProps` in the option table, the default-config block and the client docs, and gets a section of its own under *Binding and Deep Insert*. `composition-only` needs more than a table cell:

- what each of the three values does
- that it exists for CAP, whose deep writes run along compositions only — a nested entity on an association is a 400 for a to-one and a silent no-op for a to-many
- how to make CAP state the containment it reads, both the `package.json` flag and the per-composition `@odata.contained`, including that the contained target loses its own entity set
- a warning that on a server like ASP.NET Core OData — which marks containment faithfully *and* accepts deep inserts on associations — it removes properties for writes that would have succeeded
- that V2 is exempt rather than emptied

**The upgrading guide** gains a *Coming from 0.43.0 and earlier* section:

- `disableAutoManagedKey` → `keyProperties`, with the equivalences worked out against the released code: the old default is `singleComputed`, `disableAutoManagedKey: true` is `strict`, and the new `interoperable` default leaves a single key present-but-optional where it used to be absent
- managed properties now derived from `Core.*` annotations, and how to switch that off
- `update()` / `patch()` may take an Updatable model
- `has` is offered only for flags enums — the one entry that makes code stop compiling
- enum synthesis, noted as new and opt-in, linking to the existing section rather than repeating it
- `disableDeepInsertProps` → `deepInsertProps`

**`managedPropertyDetection` is deliberately absent.** It was introduced on 2026-08-12 and replaced before any release; the last release, 0.43.0, has no trace of it. Nobody can be upgrading from it, so documenting it would only invite people to look for an option they never had.

Verified against the released tree rather than from memory: `disableDeepInsertProps` and `disableAutoManagedKey` are in 0.43.0, while `keyProperties`, `managedPropertyMode`, `annotations`, `enumSynthesized` and `managedPropertyDetection` are not. The site builds, so no anchor is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)