### PR TITLE
feat(configuration): document ts-nocheck opt-in and what changed since 0.44.0

### DIFF
--- a/docs/04-generator/02-configuration.md
+++ b/docs/04-generator/02-configuration.md
@@ -32,6 +32,7 @@ const defaultConfig = {
   mode: Modes.all,
   emitMode: EmitModes.js_dts,
   debug: false,
+  enableTsNoCheck: false,
   prettier: false,
   tsconfig: "tsconfig.json",
   converters: [],
@@ -196,7 +197,8 @@ Here is the list of all **base settings** of the config file. By and large this 
 | annotations                         | `AnnotationOptions`                       | `{}`              | What odata2ts reads out of the annotations of the service. See [annotations](#annotations)                                                                                                       |
 | keyProperties                       | `KeyProperties`                           | `"interoperable"` | What an unannotated key property is taken to be. Allowed are: interoperable, strict, singleComputed, singleComputedComplexOptional, allComputed. See [key properties](#keys--managed-properties) |
 | managedPropertyMode                 | `ManagedPropertyMode`                     | `"lenient"`       | How a managed property shows up in the generated write models. Allowed are: lenient, strictOmit. See [managed properties](#optional-vs-omit)                                                     |
-| debug                               | `boolean`                                 | `false`           | Turn off adding `ts-nocheck` to all generated artefacts; prints out debug information                                                                                                            |
+| debug                               | `boolean`                                 | `false`           | Prints out debug information (CLI options, resolved config, metadata-download requests)                                                                                                          |
+| enableTsNoCheck                     | `boolean`                                 | `false`           | Add `// @ts-nocheck` to the top of every generated file, skipping downstream type checking for a faster build. Independent of `debug`.                                                           |
 | serviceName                         | `string`                                  |                   | Overwrites the service name found in OData metadata. But only makes sense on this level when `source` & `output` are specified via CLI options.                                                  |
 | skipEditableModels                  | `boolean`                                 | `false`           | Don't generate separate models for manipulating actions (create, update, patch). See [fine-tuning artefact generation](#fine-tuning-artefact-generation)                                         |
 | skipIdModels                        | `boolean`                                 | `false`           | Don't generate separate models & q-objects for entity ids. See [fine-tuning artefact generation](#fine-tuning-artefact-generation)                                                               |
@@ -262,7 +264,8 @@ As you can see, this largely matches the **base settings**:
 | `--allow-renaming`<br/>`-r` | `false`           | Allow renaming of model entities and their props by applying naming strategies like camelCase or PascalCase. See [renaming properties](#renaming-entities-and-properties)                        |
 | `--key-properties`          | `"interoperable"` | What an unannotated key property is taken to be. Allowed are: interoperable, strict, singleComputed, singleComputedComplexOptional, allComputed. See [key properties](#keys--managed-properties) |
 | `--managed-property-mode`   | `"lenient"`       | How a managed property shows up in the generated write models. Allowed are: lenient, strictOmit. See [managed properties](#optional-vs-omit)                                                     |
-| `--debug`<br/>`-d`          | `false`           | Add debug information; also removes the `@ts-nocheck` comment from each generated file                                                                                                           |
+| `--debug`<br/>`-d`          | `false`           | Add debug information (CLI options, resolved config, metadata-download requests)                                                                                                                 |
+| `--enable-ts-no-check`      | `false`           | Add `// @ts-nocheck` to the top of every generated file, skipping downstream type checking for a faster build. Independent of `--debug`.                                                         |
 
 Besides options, the CLI takes any number of **service names** as arguments. Each must exist in the config
 file, and only those services are generated:

--- a/docs/09-upgrading.md
+++ b/docs/09-upgrading.md
@@ -8,6 +8,25 @@ sidebar_position: 9
 
 What changes between releases in ways that need something from you. Everything else is additive.
 
+## Coming from 0.44.0 and earlier
+
+### `// @ts-nocheck` is now opt-in, and no longer tied to `debug`
+
+Generated files used to open with `// @ts-nocheck` unless you set `debug: true` — a flag whose real
+purpose is unrelated verbose logging (CLI options, resolved config, metadata-download requests). The two
+are now fully independent: `debug` no longer affects type checking, and a new option,
+`enableTsNoCheck` (`--enable-ts-no-check` on the CLI), is the sole switch for the header.
+
+| before                                  | equivalent now          |
+| --------------------------------------- | ----------------------- |
+| the default                             | `enableTsNoCheck: true` |
+| `debug: true` (to disable `ts-nocheck`) | the default             |
+
+The default flips along with it: generated code is **type-checked by default** now, trading the build-time
+performance of skipping downstream `tsc` checks for safety by default. If you were relying on the old
+unconditional `// @ts-nocheck` and your generated code doesn't currently type-check cleanly, set
+`enableTsNoCheck: true` to keep the old behavior until you have time to address it.
+
 ## Coming from 0.43.0 and earlier
 
 ### `disableAutoManagedKey` is now `keyProperties`
@@ -341,8 +360,9 @@ result off `execute()`.
 
 ## Checking your setup
 
-Two settings are worth having whatever you upgrade from:
+Two settings are worth checking whatever you upgrade from:
 
-- **`debug: true`** while you sort things out. Without it every generated file opens with `@ts-nocheck`,
-  so a type check over the output confirms nothing.
+- **Leave `enableTsNoCheck` unset (or `false`)** while you sort things out. That's the default since
+  0.44.0, and it's what lets a type check over the generated output mean something; setting it to `true`
+  brings back `// @ts-nocheck` and makes such a check confirm nothing.
 - **`prettier: true`** if you emit TypeScript and read the result.


### PR DESCRIPTION
- Document the new `enableTsNoCheck` config option and `--enable-ts-no-check` CLI flag, replacing the old `debug`-gated description
- Add an upgrading-guide entry for the breaking default flip (odata2ts/odata2ts#546)
- Fix the now-stale "set `debug: true` while migrating" tip